### PR TITLE
Bump up base & sdl2 version bounds

### DIFF
--- a/sdl2-image.cabal
+++ b/sdl2-image.cabal
@@ -28,8 +28,8 @@ library
     SDL2_image >= 2.0.0
 
   build-depends:
-    base ==4.6.*,
-    sdl2 ==1.0.*
+    base >= 4.6 && < 4.8,
+    sdl2 >= 1.0 && < 1.2
 
   hs-source-dirs:
     src


### PR DESCRIPTION
`sdl2` released a new version `1.1` recently, and GHC 7.8 uses `base 4.7`. The package already works with both of them, so I just increased the version bounds.
