### PR TITLE
Use SDL instead of sdl for extra-libraries

### DIFF
--- a/sdl2-image.cabal
+++ b/sdl2-image.cabal
@@ -1,5 +1,5 @@
 name:                sdl2-image
-version:             0.1.0.1
+version:             0.1.1.1
 synopsis:            Haskell binding to sdl2-image.
 description:         Haskell binding to sdl2-image.
 license:             MIT
@@ -21,7 +21,7 @@ source-repository this
 
 library
   extra-libraries:
-    sdl2
+    SDL2
 
   pkgconfig-depends:
     sdl2 >= 2.0.1,


### PR DESCRIPTION
The problem I had with my machine was that SDL2-image wouldn't compile because of the "extra-libraries: sdl2" line in the cabal file. I have /usr/lib64/libSDL2.so (upper case), so cabal couldn't find the .so file. Are you working on a Windows machine and didn't notice because of that? Or does your distribution ship with libsdl2.so?
