### PR TITLE
Bump up sdl2 version bound to support 1.3.0

### DIFF
--- a/sdl2-image.cabal
+++ b/sdl2-image.cabal
@@ -29,7 +29,7 @@ library
 
   build-depends:
     base >= 4.6 && < 4.8,
-    sdl2 >= 1.0 && < 1.2
+    sdl2 >= 1.0 && < 1.4
 
   hs-source-dirs:
     src


### PR DESCRIPTION
https://hackage.haskell.org/package/sdl2 is up to 1.3.0, but hs-sdl2-image appears to work with it without changes. I've been using it for a while with [my app](https://github.com/mtolly/jelly) and have yet to run into any problems.
